### PR TITLE
Moved imports and use(apiRouter) to top

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 const Joi = require('joi');
 const express = require('express');
 const app = express();
+const apiRouter = require('./routes/api');
+const { schema } = require('joi/lib/types/object');
 
 app.use(express.json());
+app.use('/api', apiRouter);
 
 const port = 3000;
 app.listen(port, console.log(`Listening on port ${port}`))
@@ -18,8 +21,3 @@ function validateProd(prod){
 
     return Joi.validate(prod, schema);
 }
-
-const { schema } = require('joi/lib/types/object');
-
-const apiRouter = require('./routes/api');
-app.use('/api', apiRouter);


### PR DESCRIPTION
Using Functions before importing them might still work but they still cause an overhead because of the hoisting that javascript performs, better to keep all imports at top level. Another thing the order in which you use app.use() matters so these must also be kept at top level, for example if you use ```app.use('/api', apiRouter)``` before ```app.use(express.json)```, then the apiRouter won't get support for parsing json bodies. So keep imports and app.use statements at top level, they also quickly tell another developer looking at your code about what libraries and routes you are using.